### PR TITLE
Fix await SyntaxError

### DIFF
--- a/part-1/mayhem_7.py
+++ b/part-1/mayhem_7.py
@@ -93,7 +93,7 @@ async def save(msg):
 #####
 # Illustrates a callback approach
 #####
-def cleanup(msg, fut):
+async def cleanup(msg, fut):
     """Cleanup tasks related to completing work on a message.
 
     Args:


### PR DESCRIPTION
Otherwise, `part-1/mayhem_7.py` does not execute
```text
~/src/mayhem/venv/bin/python ~/src/mayhem/part-1/mayhem_7.py
  File "~/src/mayhem/part-1/mayhem_7.py", line 105
    await asyncio.sleep(random.random())
    ^
SyntaxError: 'await' outside async function

Process finished with exit code 1
```